### PR TITLE
docs: CODEOWNERSファイルを追加

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,22 @@
+# Gmail Calendar Sync - Code Owners
+# 
+# This file defines individuals or teams that are responsible 
+# for code in this repository.
+#
+# Lines starting with '#' are comments.
+# Each line is a file pattern followed by one or more owners.
+
+# Global owner - all files require review from yoshi65
+* @yoshi65
+
+# Specific patterns for critical files
+/.github/ @yoshi65
+/src/ @yoshi65
+/tests/ @yoshi65
+pyproject.toml @yoshi65
+README.md @yoshi65
+CLAUDE.md @yoshi65
+
+# Security-sensitive files require explicit approval
+.env.example @yoshi65
+get_refresh_token.py @yoshi65


### PR DESCRIPTION
## 概要

Branch protection rulesでcodeowner要件が必須になっているため、CODEOWNERSファイルを追加します。

## 変更内容

- \ ファイルを追加
- 全ファイルで@yoshi65のレビューを必須に設定
- セキュリティ重要ファイル（認証関連）に明示的な承認を設定

## 確認事項

- [x] CODEOWNERSファイルの構文が正しい
- [x] 適切なオーナー設定
- [x] セキュリティファイルの明示的指定

## 影響

Branch protectionルールが正常に動作し、コードレビューが適切に機能するようになります。