### PR TITLE
fix: GCP_SA_KEY から project_id を抽出し GCP_PROJECT_ID secret を不要に

### DIFF
--- a/.github/workflows/repo-maintenance.yml
+++ b/.github/workflows/repo-maintenance.yml
@@ -55,8 +55,9 @@ jobs:
 
       - name: Clean up old images (keep 10 most recent)
         env:
-          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+          GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
         run: |
+          GCP_PROJECT_ID=$(echo "$GCP_SA_KEY" | jq -r '.project_id')
           REGISTRY="asia-northeast1-docker.pkg.dev/${GCP_PROJECT_ID}/gmail-calendar-sync/gmail-calendar-sync"
 
           # List digests sorted by update time (newest first), skip first 10, delete the rest


### PR DESCRIPTION
## Summary
- Artifact Registry cleanup ジョブで `GCP_PROJECT_ID` secret を別途必要としていたのを、既存の `GCP_SA_KEY` から `jq` で `project_id` を抽出する方式に変更
- 新しい secret の追加が不要になる

## Test plan
- [ ] `repo-maintenance.yml` の cleanup-artifact-registry ジョブが正常動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)